### PR TITLE
quick fix to URL parameters

### DIFF
--- a/routes/forums.js
+++ b/routes/forums.js
@@ -42,19 +42,7 @@ router.get('/', function(req, res, next) {
     //default
     res.redirect('/forums/1')
 })
-router.get('/:page', function(req, res, next) {
-    if(req.params.page < 1) {
-        res.render('404')
-        return
-    }
-    var query = req.query.query
-    res.render('forums', {
-        user: req.session.user, 
-        specialRole: req.session.specialRole, 
-        pageNum: req.params.page,
-        query: query
-    })
-})
+
 /*
 Wrap ObjectIds in tryCatch because it throws error if it isn't a correct input(24byte char array)
 */
@@ -127,6 +115,20 @@ router.get('/comment/:id/delete', async function(req, res, next) {
     }
     await db.deleteDoc('users', 'comments', req.params.id)
     res.redirect('/forums/posts/' + postID)
+})
+
+router.get('/:page', function(req, res, next) {
+    if(req.params.page < 1) {
+        res.render('404')
+        return
+    }
+    var query = req.query.query
+    res.render('forums', {
+        user: req.session.user, 
+        specialRole: req.session.specialRole, 
+        pageNum: req.params.page,
+        query: query
+    })
 })
 
 module.exports = router


### PR DESCRIPTION
## Pagination Bugfix: URL Parameters
- Fixes error raised when visiting forums/createPost caused by express.js thinking that createPost was one of the url parameters.
- Fixed by moving `router.get('/:pageNum')` to the bottom of the routes js file.